### PR TITLE
Implement graphite byproduct ledger

### DIFF
--- a/core/steel_plant.py
+++ b/core/steel_plant.py
@@ -1,7 +1,7 @@
 """Simplified steel plant model hooking in hydrogen supply blocks."""
 from typing import Dict, Sequence
 
-from supply import HazerSupply, ElectrolysisSupply
+from supply import HazerSupply, ElectrolysisSupply, GraphiteLedger
 
 
 SUPPLY_MAP = {
@@ -10,7 +10,15 @@ SUPPLY_MAP = {
 }
 
 
-def run_steel_plant(demand_profile: Sequence[float], supply_type: str = 'hazer') -> Dict[str, float]:
+CARBON_FINES_PRICE = 0.18  # USD per kg
+ELECTRODE_PRICE = 3.0      # USD per kg
+
+
+def run_steel_plant(
+    demand_profile: Sequence[float],
+    supply_type: str = 'hazer',
+    ledger: GraphiteLedger | None = None,
+) -> Dict[str, float]:
     """Compute rough cost and emission results for a steel plant."""
     SupplyCls = SUPPLY_MAP[supply_type]
     supply = SupplyCls(demand_profile)
@@ -19,9 +27,18 @@ def run_steel_plant(demand_profile: Sequence[float], supply_type: str = 'hazer')
     costs = supply.capex_opex()
     impacts = supply.lca()
 
-    return {
+    result = {
         'h2_kg': flows['H2'],
         'supply_capex': costs['capex'],
         'lcoh': costs['lcoh'],
         'supply_emissions_kg': impacts['total_kg_co2'],
     }
+
+    if ledger is not None:
+        byprod = supply.byproducts()
+        ledger.flow = byprod.get('graphite', 0.0)
+        ledger.allocate()
+        result['avoided_fines_usd'] = ledger.to_fines * CARBON_FINES_PRICE
+        result['avoided_electrodes_usd'] = ledger.to_electrodes * ELECTRODE_PRICE
+
+    return result

--- a/run_example.py
+++ b/run_example.py
@@ -1,8 +1,10 @@
 """Simple driver script demonstrating the Hazer supply block."""
 from core.steel_plant import run_steel_plant
 from typing import List
+from supply import GraphiteLedger
 
 if __name__ == "__main__":
     demand: List[float] = [7550 / 24] * 24
-    result = run_steel_plant(demand, supply_type="hazer")
+    ledger = GraphiteLedger(0.0)
+    result = run_steel_plant(demand, supply_type="hazer", ledger=ledger)
     print(result)

--- a/supply/__init__.py
+++ b/supply/__init__.py
@@ -1,6 +1,7 @@
 from .base import SupplyBlock
 from .pyrolysis_hazer import HazerSupply, HazerParams
 from .electrolysis import ElectrolysisSupply, ElectrolysisParams
+from .graphite import GraphiteLedger
 
 __all__ = [
     'SupplyBlock',
@@ -8,4 +9,5 @@ __all__ = [
     'HazerParams',
     'ElectrolysisSupply',
     'ElectrolysisParams',
+    'GraphiteLedger',
 ]

--- a/supply/base.py
+++ b/supply/base.py
@@ -23,3 +23,8 @@ class SupplyBlock(ABC):
     def lca(self) -> Dict[str, float]:
         """Return lifecycle assessment metrics."""
         raise NotImplementedError
+
+    @abstractmethod
+    def byproducts(self) -> Dict[str, float]:
+        """Return mass flows of key byproducts like graphite."""
+        raise NotImplementedError

--- a/supply/graphite.py
+++ b/supply/graphite.py
@@ -1,0 +1,14 @@
+class GraphiteLedger:
+    """Simple ledger for allocating Hazer graphite."""
+
+    def __init__(self, flow_kg_h: float):
+        self.flow = float(flow_kg_h)
+        self.to_fines = 0.0
+        self.to_electrodes = 0.0
+        self.to_sale = self.flow
+
+    def allocate(self, eaf_fines: float = 20.0, electrodes: float = 1.8) -> None:
+        """Allocate graphite to internal uses then sale."""
+        self.to_fines = eaf_fines
+        self.to_electrodes = electrodes
+        self.to_sale = max(0.0, self.flow - eaf_fines - electrodes)

--- a/supply/pyrolysis_hazer.py
+++ b/supply/pyrolysis_hazer.py
@@ -58,3 +58,12 @@ class HazerSupply(SupplyBlock):
             "kg_co2_per_kg_h2": total_co2 / flows["H2"],
             "total_kg_co2": total_co2,
         }
+
+    def byproducts(self) -> Dict[str, float]:
+        """Return mass flows of graphite, tail-gas and catalyst."""
+        h2_total = float(sum(self.demand))
+        return {
+            "graphite": h2_total * self.params.graphite_per_h2,
+            "tail_gas": h2_total * 0.15,  # kg per kg H2 from PSA slip-stream
+            "catalyst": h2_total * 0.8,   # kg Fe ore make-up per kg H2
+        }


### PR DESCRIPTION
## Summary
- extend `SupplyBlock` with `byproducts()` abstract method
- implement byproducts handling for `HazerSupply`
- add `GraphiteLedger` helper and export in package
- allow `run_steel_plant()` to use a ledger and report avoided electrode/fines costs
- update example script for new ledger workflow

## Testing
- `python run_example.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6874912e001083299863683e6aaa87dc