### PR TITLE
Add YAML scenario runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ print(result)
 ```
 
 This returns a dictionary with total hydrogen produced, supply CAPEX, levelised cost of hydrogen and associated CO₂ emissions.
+
+## Scenario runner
+
+`core.run_scenarios` executes a supply block based on a YAML configuration and prints a table of key outputs.
+
+```bash
+python -m core.run_scenarios example_scenario.yaml
+```
+
+The provided `example_scenario.yaml` defines keys such as `H2_source`, `graphite_price`, energy prices and the graphite allocation fraction.

--- a/core/run_scenarios.py
+++ b/core/run_scenarios.py
@@ -1,0 +1,74 @@
+"""Run H2 supply scenarios configured by a YAML file."""
+import sys
+from typing import Sequence
+
+import yaml
+
+from supply import (
+    HazerSupply,
+    ElectrolysisSupply,
+    HazerParams,
+    ElectrolysisParams,
+    elec_price_default,
+)
+
+
+SUPPLY_CLASSES = {
+    "hazer": HazerSupply,
+    "electrolysis": ElectrolysisSupply,
+}
+
+
+def build_supply(demand: Sequence[float], cfg: dict):
+    """Instantiate the requested supply block with parameters from cfg."""
+    source = cfg.get("H2_source", "hazer")
+    if source not in SUPPLY_CLASSES:
+        raise ValueError(f"Unknown H2_source '{source}'")
+
+    if source == "hazer":
+        params = HazerParams()
+        if "graphite_price" in cfg:
+            params.graphite_price = cfg["graphite_price"]
+        if "ng_price" in cfg:
+            params.ng_price = cfg["ng_price"]
+        return HazerSupply(demand, params)
+
+    params = ElectrolysisParams()
+    elec_price = cfg.get("elec_price", elec_price_default)
+    return ElectrolysisSupply(demand, params, elec_price=elec_price)
+
+
+def format_table(results: dict) -> str:
+    max_key = max(len(k) for k in results)
+    lines = ["Metric".ljust(max_key) + "  Value", "-" * (max_key + 7)]
+    for k, v in results.items():
+        if isinstance(v, float):
+            val = f"{v:.3f}"
+        else:
+            val = str(v)
+        lines.append(f"{k.ljust(max_key)}  {val}")
+    return "\n".join(lines)
+
+
+def main(path: str) -> None:
+    with open(path) as f:
+        cfg = yaml.safe_load(f)
+
+    demand_tpd = float(cfg.get("h2_demand_tpd", 7.55))
+    demand_profile = [demand_tpd * 1000 / 24] * 24
+
+    supply = build_supply(demand_profile, cfg)
+    results = {
+        **supply.mass_energy(),
+        **supply.capex_opex(),
+        **supply.lca(),
+    }
+
+    print(format_table(results))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python -m core.run_scenarios <config.yaml>")
+        raise SystemExit(1)
+    main(sys.argv[1])

--- a/example_scenario.yaml
+++ b/example_scenario.yaml
@@ -1,0 +1,11 @@
+H2_source: hazer
+# price for selling graphite (USD per kg)
+graphite_price: 0.8
+# electricity price in USD per kWh (used for electrolysis)
+elec_price: 0.05
+# natural gas price in USD per kg CH4 (used for pyrolysis)
+ng_price: 4.0
+# fraction of graphite sold (0-1)
+graphite_allocation: 1.0
+# hydrogen demand in tonnes per day
+h2_demand_tpd: 7.55


### PR DESCRIPTION
## Summary
- add `core.run_scenarios` to execute H₂ supply scenarios from a YAML file
- ship example configuration file
- document scenario runner usage

## Testing
- `python -m core.run_scenarios example_scenario.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6874913476488329914c13940154ca64