### PR TITLE
Add simple web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ python -m core.run_scenarios example_scenario.yaml
 
 The provided `example_scenario.yaml` defines keys such as `H2_source`, `graphite_price`, energy prices and the graphite allocation fraction.
 
+
+## Web demo
+
+A small web server in `web/app.py` visualises outputs. Start it from the repo
+root and open `http://localhost:8000` in a browser:
+
+```bash
+python web/app.py
+```
+
+Select a supply type and press *Run* to see the resulting costs and emissions.

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,32 @@
+import json
+import os
+import sys
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from core.steel_plant import run_steel_plant
+
+class Handler(SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.path.startswith('/api/run'):
+            qs = parse_qs(urlparse(self.path).query)
+            supply = qs.get('type', ['hazer'])[0]
+            demand = [7550 / 24] * 24
+            result = run_steel_plant(demand, supply_type=supply)
+            data = json.dumps(result).encode()
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            super().do_GET()
+
+
+def main():
+    HTTPServer(('0.0.0.0', 8000), Handler).serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Hydrogen Steel Plant Demo</title>
+</head>
+<body>
+<h1>Hydrogen Steel Plant Demo</h1>
+<p>
+  Supply type:
+  <select id="type">
+    <option value="hazer">Hazer</option>
+    <option value="electrolysis">Electrolysis</option>
+  </select>
+  <button onclick="runModel()">Run</button>
+</p>
+<pre id="output"></pre>
+<script>
+function runModel() {
+  const type = document.getElementById('type').value;
+  fetch('/api/run?type=' + encodeURIComponent(type))
+    .then(r => r.json())
+    .then(data => {
+      document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+    })
+    .catch(err => {
+      document.getElementById('output').textContent = 'Error: ' + err;
+    });
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add basic web demo using only standard library
- document demo in README

## Testing
- `pytest -q`
- `python web/app.py & sleep 1; curl -s http://localhost:8000/api/run?type=hazer; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68749bc9974c8329b12f28cee8b5fe7f